### PR TITLE
🛠️ build: Add Postgres override config for DDEV

### DIFF
--- a/.ddev/config.postgres.yaml
+++ b/.ddev/config.postgres.yaml
@@ -1,0 +1,3 @@
+database:
+    type: postgres
+    version: "17"


### PR DESCRIPTION
Adds .ddev/config.postgres.yaml to enable a Postgres 17 database in the feature branch without modifying the main environment. This keeps branch-specific DB settings out of versioned config and prevents breaking main during local development.